### PR TITLE
feat: Add images to drone service cards and other pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -82,7 +82,7 @@
 
         <section class="contact-section">
             <div class="container">
-                <div class="contact-wrapper animate-on-scroll">
+                <div class="contact-wrapper-grid animate-on-scroll">
                     <div class="contact-info-card">
                         <h3>Contact Details</h3>
                         <p>Find us at our headquarters or reach out via our digital channels.</p>
@@ -106,6 +106,9 @@
                                 referrerpolicy="no-referrer-when-downgrade">
                             </iframe>
                         </div>
+                    </div>
+                    <div class="contact-image-container">
+                        <img src="assets/images/drotalk.png" alt="Drone Consultation">
                     </div>
                 </div>
             </div>

--- a/css/style.css
+++ b/css/style.css
@@ -539,6 +539,26 @@ section {
     font-weight: 500;
 }
 
+.contact-wrapper-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: center;
+}
+
+.contact-image-container {
+    width: 100%;
+    height: 100%;
+    border-radius: 16px;
+    overflow: hidden;
+}
+
+.contact-image-container img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
 /* Programs Page */
 .program-grid {
     display: grid;
@@ -731,10 +751,38 @@ section {
 .dark-theme .service-card-detailed:hover {
     box-shadow: 0 15px 30px rgba(0,0,0,0.2);
 }
+.service-card-detailed {
+    display: flex;
+    flex-direction: column;
+}
+
+.service-card-detailed .card-image {
+    width: 100%;
+    height: 200px;
+    overflow: hidden;
+    border-radius: 12px 12px 0 0;
+}
+
+.service-card-detailed .card-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
 .service-card-detailed h3 {
     font-size: 1.5rem;
     margin-bottom: 1rem;
     color: var(--primary-color);
+    margin-top: 1.5rem;
+}
+
+.service-card-detailed p {
+    flex-grow: 1;
+}
+
+.service-card-detailed .btn {
+    margin-top: 1.5rem;
+    align-self: flex-start;
 }
 .cta-section {
     text-align: center;
@@ -897,6 +945,29 @@ body.dark-theme .hero-visual.animate-in {
 .animate-on-scroll.is-visible {
     opacity: 1;
     transform: translateY(0);
+}
+
+.floating-drone {
+    position: fixed;
+    bottom: 150px;
+    right: -50px;
+    width: 200px;
+    height: auto;
+    z-index: 999;
+    animation: float 6s ease-in-out infinite;
+    filter: drop-shadow(0 10px 20px rgba(0,0,0,0.2));
+}
+
+@keyframes float {
+    0% {
+        transform: translateY(0px) translateX(0px) rotate(0deg);
+    }
+    50% {
+        transform: translateY(-20px) translateX(-20px) rotate(10deg);
+    }
+    100% {
+        transform: translateY(0px) translateX(0px) rotate(0deg);
+    }
 }
 
 /* 8. Responsive Design */

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <img src="assets/images/dro.png" alt="Floating Drone" class="floating-drone">
 
     <header class="header">
         <nav class="navbar">
@@ -77,21 +78,37 @@
             </div>
         </section>
 
-       <section class="drone-services">
+        <section class="drone-services">
             <div class="container">
                 <h2 class="section-title animate-on-scroll">Our Drone Services</h2>
-                <div class="services-grid animate-on-scroll">
-                    <div class="service-item">Construction and Engineering</div>
-                    <div class="service-item">Infrastructure and Transportation</div>
-                    <div class="service-item">Property Development and Maintainance</div>
-                    <div class="service-item">Public Safety</div>
-                    <div class="service-item">Virtual Tours, Video and Photography</div>
-                    <div class="service-item">3D Modelling</div>
-                    <div class="service-item">Infra-Red</div>
-                    <div class="service-item">LIDAR (including vegetation strip back)</div>
+                <div class="services-grid-detailed animate-on-scroll">
+                    <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Construction Drone">
+                        </div>
+                        <h3>Construction and Engineering</h3>
+                        <p>Monitor project progress, conduct site surveys, and ensure safety with high-resolution aerial imagery and data.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
+                    </div>
+                    <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Infrastructure Drone">
+                        </div>
+                        <h3>Infrastructure and Transportation</h3>
+                        <p>Inspect bridges, roads, and other critical infrastructure efficiently and safely, identifying potential issues before they become major problems.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
+                    </div>
+                    <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Real Estate Drone">
+                        </div>
+                        <h3>Property Development and Maintainance</h3>
+                        <p>Showcase properties from stunning aerial perspectives, and perform maintainance inspections with ease.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
+                    </div>
                 </div>
                 <div class="animate-on-scroll" style="text-align: center; margin-top: 2rem;">
-                    <a href="services.html" class="btn btn-primary">Learn More</a>
+                    <a href="services.html" class="btn btn-secondary">View All Services</a>
                 </div>
             </div>
         </section>

--- a/services.html
+++ b/services.html
@@ -46,43 +46,75 @@
             <div class="container">
                 <div class="services-grid-detailed animate-on-scroll">
                     <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Construction Drone">
+                        </div>
                         <h3>Construction and Engineering</h3>
                         <p>Monitor project progress, conduct site surveys, and ensure safety with high-resolution aerial imagery and data.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
                     </div>
                     <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Infrastructure Drone">
+                        </div>
                         <h3>Infrastructure and Transportation</h3>
                         <p>Inspect bridges, roads, and other critical infrastructure efficiently and safely, identifying potential issues before they become major problems.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
                     </div>
                     <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Real Estate Drone">
+                        </div>
                         <h3>Property Development and Maintainance</h3>
                         <p>Showcase properties from stunning aerial perspectives, and perform maintainance inspections with ease.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
                     </div>
                     <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Public Safety Drone">
+                        </div>
                         <h3>Public Safety</h3>
                         <p>Enhance situational awareness for emergency response, search and rescue operations, and event monitoring.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
                     </div>
                     <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Photography Drone">
+                        </div>
                         <h3>Virtual Tours, Video and Photography</h3>
                         <p>Create immersive virtual tours and capture breathtaking aerial photos and videos for marketing, tourism, and more.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
                     </div>
                     <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="3D Modelling Drone">
+                        </div>
                         <h3>3D Modelling</h3>
                         <p>Generate accurate 3D models of buildings, terrain, and other assets for planning, analysis, and visualization.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
                     </div>
                     <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="Infra-Red Drone">
+                        </div>
                         <h3>Infra-Red</h3>
                         <p>Utilize thermal imaging for a variety of applications, including energy audits, agricultural analysis, and search and rescue.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
                     </div>
                     <div class="service-card-detailed">
+                        <div class="card-image">
+                            <img src="assets/images/dro.png" alt="LIDAR Drone">
+                        </div>
                         <h3>LIDAR</h3>
                         <p>Capture highly accurate elevation data for detailed topographic mapping, forestry management, and vegetation strip back.</p>
+                        <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary" target="_blank">Book A Demo</a>
                     </div>
                 </div>
 
                 <div class="cta-section animate-on-scroll">
                     <h2>Ready to elevate your project?</h2>
                     <p>Contact us today to discuss your specific needs and learn how our drone services can benefit you.</p>
-                    <a href="contact.html" class="btn btn-primary btn-large">Book A Demo</a>
+                    <a href="https://wa.me/2348032899111?text=I%20need%20your%20drone%20service" class="btn btn-primary btn-large" target="_blank">Book A Demo</a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
This commit introduces several visual enhancements to the website:

- Redesigns the drone service cards on the home and services pages to include images, descriptions, and a "Book A Demo" button that links to WhatsApp.
- Adds a floating drone image to the home page for a more dynamic user experience.
- Adds an image to the contact section of the about page, with a new grid layout to accommodate the image.
- Adds two new images to the `assets/images` directory to be used in the new layouts.