### PR TITLE
Fix image fitting and expand functionality on services page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -760,13 +760,16 @@ section {
     width: 100%;
     height: 200px;
     overflow: hidden;
-    border-radius: 12px 12px 0 0;
+    border-radius: 8px;
+    margin-bottom: 1.5rem;
+    background-color: var(--bg-color);
 }
 
 .service-card-detailed .card-image img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
+    transition: transform var(--transition-speed);
 }
 
 .service-card-detailed h3 {

--- a/services.html
+++ b/services.html
@@ -120,6 +120,12 @@
         </section>
     </main>
 
+    <!-- Image Modal -->
+    <div id="image-modal" class="modal">
+        <span class="close-modal">&times;</span>
+        <img class="modal-content" id="modal-image">
+    </div>
+
     <footer class="footer">
         <div class="container footer-container">
             <div class="footer-col">


### PR DESCRIPTION
The images in the drone services cards were not properly fitted. This was fixed by changing the `object-fit` property from `cover` to `contain` in `css/style.css`.

The image expand functionality was not working because the modal HTML was missing from `services.html`. This has been added, and the existing CSS and JavaScript for the modal now function as intended.