### PR TITLE
Fix sticky image and update chatbot assistant

### DIFF
--- a/about.html
+++ b/about.html
@@ -165,9 +165,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="chatbot-icon">
-            <path fill-rule="evenodd" d="M4.5 3.75a3 3 0 00-3 3v10.5a3 3 0 003 3h15a3 3 0 003-3V6.75a3 3 0 00-3-3h-15zm4.125 3a.75.75 0 000 1.5h6.75a.75.75 0 000-1.5h-6.75zm-3 3.75a.75.75 0 01.75-.75h11.25a.75.75 0 010 1.5H6.375a.75.75 0 01-.75-.75zm.75 2.25a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zm5.25 0a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" clip-rule="evenodd" />
-        </svg>
+        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -103,9 +103,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="chatbot-icon">
-            <path fill-rule="evenodd" d="M4.5 3.75a3 3 0 00-3 3v10.5a3 3 0 003 3h15a3 3 0 003-3V6.75a3 3 0 00-3-3h-15zm4.125 3a.75.75 0 000 1.5h6.75a.75.75 0 000-1.5h-6.75zm-3 3.75a.75.75 0 01.75-.75h11.25a.75.75 0 010 1.5H6.375a.75.75 0 01-.75-.75zm.75 2.25a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zm5.25 0a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" clip-rule="evenodd" />
-        </svg>
+        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
 <footer class="footer">
         <div class="container footer-container">

--- a/css/style.css
+++ b/css/style.css
@@ -969,7 +969,7 @@ body.dark-theme .hero-visual.animate-in {
 .floating-drone {
     position: fixed;
     bottom: 150px;
-    right: -50px;
+    right: 20px;
     width: 200px;
     height: auto;
     z-index: 999;
@@ -1230,9 +1230,10 @@ body.dark-theme .hero-visual.animate-in {
     z-index: 1000;
 }
 
-.chatbot-toggle-btn svg {
-    width: 30px;
-    height: 30px;
+.chatbot-toggle-btn .chatbot-icon {
+    width: 40px;
+    height: 40px;
+    object-fit: contain;
 }
 
 /* Image Modal */

--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
     </header>
 
     <main>
+        <!-- Floating Drone Image -->
+        <img src="assets/images/dronetain.png" alt="Floating Drone" class="floating-drone">
+
         <section class="hero slider-container">
             <!-- Slide 1: Original Hero -->
             <div class="slide active">
@@ -188,9 +191,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="chatbot-icon">
-            <path fill-rule="evenodd" d="M4.5 3.75a3 3 0 00-3 3v10.5a3 3 0 003 3h15a3 3 0 003-3V6.75a3 3 0 00-3-3h-15zm4.125 3a.75.75 0 000 1.5h6.75a.75.75 0 000-1.5h-6.75zm-3 3.75a.75.75 0 01.75-.75h11.25a.75.75 0 010 1.5H6.375a.75.75 0 01-.75-.75zm.75 2.25a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zm5.25 0a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" clip-rule="evenodd" />
-        </svg>
+        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
 
     <script src="js/script.js"></script>

--- a/js/script.js
+++ b/js/script.js
@@ -161,7 +161,20 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    // --- 9. Blurred Background for Service Images ---
+    // --- 9. Chatbot popup ---
+    const showPopup = () => {
+        if (sessionStorage.getItem('chatbotPopupShown')) return;
+
+        setTimeout(() => {
+            chatbot.classList.add('active');
+            appendMessage("Need help? Chat with us!", 'bot-message');
+            sessionStorage.setItem('chatbotPopupShown', 'true');
+        }, 5000); // 5 seconds delay
+    };
+
+    showPopup();
+
+    // --- 10. Blurred Background for Service Images ---
     try {
         document.querySelectorAll('.service-card-detailed .card-image').forEach(cardImage => {
             const img = cardImage.querySelector('img');

--- a/pd+.html
+++ b/pd+.html
@@ -26,8 +26,8 @@
     </header>
 
     <main>
-        <!-- Placeholder for dronetain.png -->
-        <img src="assets/images/dro.jpg" alt="Sticky Drone" class="sticky-drone-placeholder">
+        <!-- Floating Drone Image -->
+        <img src="assets/images/dronetain.png" alt="Floating Drone" class="floating-drone">
         <section class="coming-soon">
             <div class="container">
                 <div class="coming-soon-content animate-in">
@@ -92,9 +92,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="chatbot-icon">
-            <path fill-rule="evenodd" d="M4.5 3.75a3 3 0 00-3 3v10.5a3 3 0 003 3h15a3 3 0 003-3V6.75a3 3 0 00-3-3h-15zm4.125 3a.75.75 0 000 1.5h6.75a.75.75 0 000-1.5h-6.75zm-3 3.75a.75.75 0 01.75-.75h11.25a.75.75 0 010 1.5H6.375a.75.75 0 01-.75-.75zm.75 2.25a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zm5.25 0a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" clip-rule="evenodd" />
-        </svg>
+        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>

--- a/programs.html
+++ b/programs.html
@@ -176,9 +176,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="chatbot-icon">
-            <path fill-rule="evenodd" d="M4.5 3.75a3 3 0 00-3 3v10.5a3 3 0 003 3h15a3 3 0 003-3V6.75a3 3 0 00-3-3h-15zm4.125 3a.75.75 0 000 1.5h6.75a.75.75 0 000-1.5h-6.75zm-3 3.75a.75.75 0 01.75-.75h11.25a.75.75 0 010 1.5H6.375a.75.75 0 01-.75-.75zm.75 2.25a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zm5.25 0a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" clip-rule="evenodd" />
-        </svg>
+        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>

--- a/services.html
+++ b/services.html
@@ -176,9 +176,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="chatbot-icon">
-            <path fill-rule="evenodd" d="M4.5 3.75a3 3 0 00-3 3v10.5a3 3 0 003 3h15a3 3 0 003-3V6.75a3 3 0 00-3-3h-15zm4.125 3a.75.75 0 000 1.5h6.75a.75.75 0 000-1.5h-6.75zm-3 3.75a.75.75 0 01.75-.75h11.25a.75.75 0 010 1.5H6.375a.75.75 0 01-.75-.75zm.75 2.25a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zm5.25 0a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" clip-rule="evenodd" />
-        </svg>
+        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>

--- a/store.html
+++ b/store.html
@@ -26,8 +26,8 @@
     </header>
 
     <main>
-        <!-- Placeholder for dronetain.png -->
-        <img src="assets/images/dro.jpg" alt="Sticky Drone" class="sticky-drone-placeholder">
+        <!-- Floating Drone Image -->
+        <img src="assets/images/dronetain.png" alt="Floating Drone" class="floating-drone">
         <section class="coming-soon">
             <div class="container">
                 <div class="coming-soon-content animate-in">
@@ -92,9 +92,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="chatbot-icon">
-            <path fill-rule="evenodd" d="M4.5 3.75a3 3 0 00-3 3v10.5a3 3 0 003 3h15a3 3 0 003-3V6.75a3 3 0 00-3-3h-15zm4.125 3a.75.75 0 000 1.5h6.75a.75.75 0 000-1.5h-6.75zm-3 3.75a.75.75 0 01.75-.75h11.25a.75.75 0 010 1.5H6.375a.75.75 0 01-.75-.75zm.75 2.25a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zm5.25 0a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z" clip-rule="evenodd" />
-        </svg>
+        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>


### PR DESCRIPTION
- Add the floating drone sticky image to the homepage, pd+, and store pages.
- Replace the chatbot's SVG icon with a robot image (`dro.png`).
- Implement a feature where the chatbot pops up with a "Chat with us!" message after a 5-second delay on the first visit of a session.
- Adjust the CSS for the floating drone to be correctly positioned on the screen.
- Adjust the CSS for the chatbot icon to be the correct size.