### PR TITLE
Fix sticky image and update chatbot assistant (v2)

### DIFF
--- a/about.html
+++ b/about.html
@@ -165,7 +165,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
+        <img src="assets/images/drotalk.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -103,7 +103,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
+        <img src="assets/images/drotalk.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
 <footer class="footer">
         <div class="container footer-container">

--- a/css/style.css
+++ b/css/style.css
@@ -968,9 +968,9 @@ body.dark-theme .hero-visual.animate-in {
 
 .floating-drone {
     position: fixed;
-    bottom: 150px;
-    right: 20px;
-    width: 200px;
+    bottom: 100px;
+    right: 10px;
+    width: 120px;
     height: auto;
     z-index: 999;
     animation: float 6s ease-in-out infinite;

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
+        <img src="assets/images/drotalk.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
 
     <script src="js/script.js"></script>

--- a/pd+.html
+++ b/pd+.html
@@ -92,7 +92,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
+        <img src="assets/images/drotalk.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>

--- a/programs.html
+++ b/programs.html
@@ -176,7 +176,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
+        <img src="assets/images/drotalk.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>

--- a/services.html
+++ b/services.html
@@ -176,7 +176,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
+        <img src="assets/images/drotalk.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>

--- a/store.html
+++ b/store.html
@@ -92,7 +92,7 @@
         </div>
     </div>
     <button class="chatbot-toggle-btn">
-        <img src="assets/images/dro.png" alt="Chatbot Icon" class="chatbot-icon">
+        <img src="assets/images/drotalk.png" alt="Chatbot Icon" class="chatbot-icon">
     </button>
     <script src="js/script.js"></script>
 </body>


### PR DESCRIPTION
This commit addresses feedback on the previous submission.

- The floating drone sticky image has been made smaller and repositioned to be less obtrusive.
- The sticky images on the `store` and `pd+` pages have been made consistent.
- The chatbot's icon has been updated to a more suitable robot icon (`drotalk.png`).